### PR TITLE
Include `files` in `PullRequest` queries

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -625,6 +625,13 @@ func PullRequestByNumber(client *Client, repo ghrepo.Interface, number int) (*Pu
 				mergeable
 				additions
 				deletions
+				files(first: 100) {
+					nodes {
+						additions
+						deletions
+						path
+					}
+				}
 				author {
 				  login
 				}
@@ -728,6 +735,13 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, baseBranch, hea
 					mergeable
 					additions
 					deletions
+					files(first: 100) {
+						nodes {
+							additions
+							deletions
+							path
+						}
+					}
 					author {
 						login
 					}


### PR DESCRIPTION
_N.B. opened on the fork for reference; not for direct merge._